### PR TITLE
feat: configurable SDL app id

### DIFF
--- a/include/SFML/Window/WindowContext.hpp
+++ b/include/SFML/Window/WindowContext.hpp
@@ -41,6 +41,7 @@ class RenderTarget;
 class RenderTexture;
 class Shader;
 class Texture;
+class Utf8String;
 class VertexBuffer;
 class VideoModeUtils;
 class Window;
@@ -157,6 +158,16 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static unsigned int getActiveThreadLocalGlContextId();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the app ID for the compositor
+    ///
+    /// The app ID is used to identify the windows to the compositor
+    /// for purposes of assigning icons, grouping and other user-defined rules
+    /// depending on the platform.
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setAppId(const Utf8String& id);
 
     ////////////////////////////////////////////////////////////
     /// \brief Check whether a thread-local OpenGL context is currently active

--- a/src/SFML/Window/WindowContext.cpp
+++ b/src/SFML/Window/WindowContext.cpp
@@ -28,6 +28,7 @@
 #include "SFML/System/Err.hpp"
 #include "SFML/System/Priv/Vec2Base.hpp"
 #include "SFML/System/SignalErrHandler.hpp"
+#include "SFML/System/Utf8String.hpp"
 
 #include "SFML/Base/Abort.hpp"
 #include "SFML/Base/Algorithm/Find.hpp"
@@ -39,6 +40,8 @@
 #include "SFML/Base/StringView.hpp"
 #include "SFML/Base/UniquePtr.hpp"
 #include "SFML/Base/Vector.hpp"
+
+#include <SDL3/SDL_hints.h>
 
 #include <mutex>
 
@@ -816,6 +819,13 @@ unsigned int WindowContext::getActiveThreadLocalGlContextId()
 {
     ensureInstalled();
     return activeGlContext.id;
+}
+
+
+////////////////////////////////////////////////////////////
+void WindowContext::setAppId(const Utf8String& id)
+{
+    SDL_SetHint(SDL_HINT_APP_ID, id.cStr());
 }
 
 


### PR DESCRIPTION
App ID can help the compositor decide on things like icons or used in user-configured rules.

https://wiki.libsdl.org/SDL3/SDL_HINT_APP_ID